### PR TITLE
chore: clean up unused shell completion sources

### DIFF
--- a/main/.zshrc
+++ b/main/.zshrc
@@ -250,6 +250,3 @@ precmd() {
 export PATH="$PATH:$(go env GOPATH)/bin"
 
 export PATH="$HOME/.local/bin:$PATH"
-
-# OpenClaw Completion
-source "/Users/andyyee/.openclaw/completions/openclaw.zsh"


### PR DESCRIPTION
## Summary
- Remove stale completion source that was duplicated in private config